### PR TITLE
Unit type policies

### DIFF
--- a/include/cursor.h
+++ b/include/cursor.h
@@ -1,5 +1,8 @@
 #pragma once
-#include "sprite.h"
+// #include "sprite.h"
+
+#include <allegro5/allegro.h>
+#include <allegro5/allegro_image.h>
 
 enum mouse_state {
     normal,
@@ -9,9 +12,7 @@ enum mouse_state {
 };
 
 class cursor{
-    
 public:
-
     cursor(ALLEGRO_BITMAP *parent, ALLEGRO_DISPLAY *display);
     void set_cursor(ALLEGRO_DISPLAY *display, int cursor_type);
     // void normal(ALLEGRO_DISPLAY *display);

--- a/include/map.h
+++ b/include/map.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "sprite.h"
+// #include "sprite.h"
 
 #include <vector>
 #include <list>
@@ -8,24 +8,24 @@
 #include <allegro5/allegro_image.h>
 
 class map {
-    public:
-        // el formato de map_file es:
-            // primer linea: size
-            // a continuacion la matriz de size x size que determina el mapa, con los numeros de tiles
-        // tile_file es un .png que contiene una fila con todos los tiles
-        map(const char * map_file, const char * tile_file);
-        void display(int x, int y);
-        void register_clickable(int x, int y, Sprite * s);
+public:
+    // el formato de map_file es:
+        // primer linea: size
+        // a continuacion la matriz de size x size que determina el mapa, con los numeros de tiles
+    // tile_file es un .png que contiene una fila con todos los tiles
+    map(const char * map_file, const char * tile_file);
+    void display(int x, int y);
+    // void register_clickable(int x, int y, Sprite * s);
 
-        int get_offset_x();
-        int get_offset_y();
+    int get_offset_x();
+    int get_offset_y();
 
-    private:
-        std::vector<std::vector<int> > matrix;
-        ALLEGRO_BITMAP * tiles;
-        int size;   // medido en tiles (el mapa es cuadrado)
-        int tile_size; // los tiles tambien son cuadrados
+private:
+    std::vector<std::vector<int> > matrix;
+    ALLEGRO_BITMAP * tiles;
+    int size;   // medido en tiles (el mapa es cuadrado)
+    int tile_size; // los tiles tambien son cuadrados
 
-        int offset_x;
-        int offset_y;
+    int offset_x;
+    int offset_y;
 };

--- a/include/sprite.h
+++ b/include/sprite.h
@@ -30,122 +30,87 @@ enum Status {
 };
 
 
-// This abstract class is used to interpret different sprite layouts.
-// That is, return the position and size of the different sprite sequences
-// on a bitmap for the 8 directions and the different status (move, attack,
-// stand, die, receive hit)
-// Note: implementing only one concrete class for now
-// TODO: consider removing this class
+// This class stores the vertical offsets for different directions.
+// Consider removing if it's too trivial.
 class SpriteLayoutInterpreter {
-private:
-    // horizontal offsets, indexed by status: idle, walk, attack, die, hit
-    static /*const*/ int x_offsets[5];// = {13 * 256, 24 * 256, 0 * 256, 8 * 256, 18 * 256};
-    // length (in frames) of the sprite sequence for every status
-    static /*const*/ int bitmap_length_by_status[5];// = {5, 8, 8, 5, 6};
-    // indexed by direction:
-    // up, up right, right, down right, down, down left, left, up left
-    // for now, the last three are mirrored from 3, 2 & 1
-    static /*const*/ int y_offsets[8];// = {0 * 256, 1 * 256, 2 * 256, 3 * 256,
-                                  // 4 * 256, 3 * 256, 2 * 256, 1 * 256};
 public:
-    static const int framesize = 256;
-    int get_x_offset(Status status) {
-        // const int x_offsets[5] = {13 * 256, 24 * 256, 0 * 256, 8 * 256, 18 * 256};
-        return x_offsets[status];
-    }
-    int get_y_offset(Direction direction) {
-        // const int y_offsets[8] = {0 * 256, 1 * 256, 2 * 256, 3 * 256,
-                                  // 4 * 256, 3 * 256, 2 * 256, 1 * 256};
-        return y_offsets[direction];
-    }
-    int get_bitmap_length(Status status) {
-        // const int bitmap_length_by_status[5] = {5, 8, 8, 5, 6};
-        return bitmap_length_by_status[status];
-    }
-};
-
-class Sprite {
-public:
-    Sprite(/*ALLEGRO_BITMAP* bitmap*//*, int framesize*/);
-    ~Sprite();
-    Sprite(const Sprite & s) = delete;
-
-    // Draw next frame in position x, y.
-    // Adds a selection animation if selected = true
-    void draw(int x, int y, bool selected);
-
-    // Clear last frame
-    // Important: clear multiple sprites in reverse order from which they were drawn
-    void clear();
-
-    void change_status(Status new_status);
-    void change_direction(Direction new_direction);
-
-    // Check whether the unit is in visible in position x, y
-    bool is_clicked(int x, int y);
-    // Check whether the position x, y is contained in the unit's frame
-    // (the frame is defined by the size of the sprite and is usually
-    // bigger than the visible region of the unit)
-    bool is_broadly_clicked(int x, int y);
-
-    ALLEGRO_COLOR get_pixel(int x, int y);
-
-    int get_framesize();
-    rectangle get_rectangle();
-
-    // Initialize the backbuffer (call this before attempting to render any sprites)
-    static void initialize(ALLEGRO_BITMAP * backbuffer);
+    static const int framesize;
 protected:
-    int current_x_offset();
-    int current_y_offset();
-    ALLEGRO_BITMAP *current_bitmap();
-
-    SpriteLayoutInterpreter layout_interpreter;
-
-    // TODO: these should be abstract methods, not dummy
-    virtual ALLEGRO_BITMAP *bitmap_of(Status status) {
-        std::cerr << "called dummy method bitmap_of\n";
-        return nullptr;
-    }
-    virtual int n_frames_of(Status status) {
-        std::cerr << "called dummy method n_frames_of\n";
-        return 0;
-    }
-
-    // Screen buffer on which all sprites are rendered
-    static ALLEGRO_BITMAP * backbuffer;
-
-    int framesize;
-
-    int frame;  // current frame number
-    Status status;
-    Direction direction;
-
-    int pos_x;
-    int pos_y;
-    // When drawn, the background is stored here for next call to clear
-    ALLEGRO_BITMAP * bg;
-
-    bool cleared;
+    static const int y_offsets[8];
 };
 
-class PirateSprite : public Sprite {
+class PirateBitmap  {
 public:
-    PirateSprite() : Sprite() {
-        std::cerr << "create pirate sprite\n";
-
-    }
-
     // Load bitmaps.
     // TODO: Might want to return success / failure
     static void initialize();
 protected:
-    ALLEGRO_BITMAP *bitmap_of(Status status) override {
-        return bmps[status];
-    }
-    int n_frames_of(Status status) override {
-        return n_frames[status];
-    }
     static ALLEGRO_BITMAP *bmps[STATUS_COUNT];
     static int n_frames[STATUS_COUNT];
 };
+
+// TODO: consider renaming SpriteBase to Sprite and Sprite to something else
+class SpriteBase : public SpriteLayoutInterpreter {
+public:
+    SpriteBase();
+    virtual ~SpriteBase();
+    SpriteBase(const SpriteBase&) = delete;
+
+    void draw(int x, int y, bool selected);
+
+    void clear();
+
+    void change_status(Status new_status);
+
+    void change_direction(Direction new_direction);
+
+    bool is_clicked(int x, int y);
+
+    bool is_broadly_clicked(int x, int y);
+
+    ALLEGRO_COLOR get_pixel(int x, int y);
+
+    rectangle get_rectangle();
+
+    int current_x_offset();
+
+    int current_y_offset();
+
+    virtual ALLEGRO_BITMAP *current_bitmap() = 0;
+
+    virtual int current_n_frames() = 0;
+
+    static void initialize(ALLEGRO_BITMAP * backbuff);
+
+    static ALLEGRO_BITMAP * backbuffer;
+
+    int frame;
+
+    Status status;
+
+    Direction direction;
+
+    int pos_x;
+
+    int pos_y;
+
+    ALLEGRO_BITMAP * bg;
+
+    bool cleared;
+
+};
+
+template <class Bitmap>
+class Sprite : public SpriteBase, public Bitmap {
+protected:
+    virtual ALLEGRO_BITMAP *current_bitmap() override {
+        return this->bmps[status];
+    }
+
+    virtual int current_n_frames() override {
+        return this->n_frames[status];
+    }
+};
+
+
+typedef Sprite<PirateBitmap> PirateSprite;

--- a/include/unit.h
+++ b/include/unit.h
@@ -25,11 +25,10 @@ public:
 
 protected:
     // Construct a Unit, getting the sprite
-    Unit(Sprite *sprite);
+    Unit(SpriteBase *sprite);
 
-    virtual ALLEGRO_BITMAP *unit_type_bitmap() = 0;
     static float speed;
-    Sprite *sprite;
+    SpriteBase *sprite;
     int pos_x;
     int pos_y;
     int dst_x;
@@ -37,15 +36,17 @@ protected:
     bool selected;
 };
 
-class Pirate : public Unit {
+// TODO: consider renaming
+template <class SpriteType>
+class ConcreteUnit : public Unit {
 public:
-    Pirate();
-    // sets static values
-    // TODO: add uninitialize to destroy the bitmaps
-    static void initialize();
-protected:
-    // stores the bitmap for the class' graphics
-    static ALLEGRO_BITMAP *unit_type_bitmap_ptr;
-    // retrieve the bitmap
-    virtual ALLEGRO_BITMAP *unit_type_bitmap();
+    ConcreteUnit();
 };
+
+template <class SpriteType>
+ConcreteUnit<SpriteType>::ConcreteUnit() :
+    Unit(new SpriteType()) // TODO delete in destructor
+    {}
+
+// Declare unit types here
+typedef ConcreteUnit<PirateSprite> Pirate;

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -2,13 +2,13 @@
 
 rectangle::rectangle() {}
 
-rectangle::rectangle(int u, int d, int l, int r) : 
+rectangle::rectangle(int u, int d, int l, int r) :
     up(u), down(d), left(l), right(r) {}
 
 rectangle rectangle::intersect(rectangle & other) {
-    return rectangle(MAX(up, other.up), 
-                     MIN(down, other.down), 
-                     MAX(left, other.left), 
+    return rectangle(MAX(up, other.up),
+                     MIN(down, other.down),
+                     MAX(left, other.left),
                      MIN(right, other.right));
 }
 
@@ -17,10 +17,10 @@ bool rectangle::is_valid() {
 }
 
 void rectangle::print() {
-    std::cout << "up: " << up 
-              << " down: " << down 
-              << " left: " << left 
-              << " right: " << right 
+    std::cout << "up: " << up
+              << " down: " << down
+              << " left: " << left
+              << " right: " << right
               << "\n";
 }
 
@@ -67,16 +67,16 @@ void drawable_rectangle::draw() {
     // Save rectangular background
     ALLEGRO_BITMAP * bg = al_get_target_bitmap();
     al_set_target_bitmap(horizontal);
-    al_draw_bitmap_region(bg, left, up, right - left, 1, 0, 0, 0);
-    al_draw_bitmap_region(bg, left, down, right - left, 1, 0, 1, 0);
+    al_draw_bitmap_region(bg, left, up, right - left + 1, 1, 0, 0, 0);
+    al_draw_bitmap_region(bg, left, down, right - left + 1, 1, 0, 1, 0);
 
     al_set_target_bitmap(vertical);
-    al_draw_bitmap_region(bg, left, up, 1, down - up, 0, 0, 0);
-    al_draw_bitmap_region(bg, right, up, 1, down - up, 1, 0, 0);
+    al_draw_bitmap_region(bg, left, up, 1, down - up + 1, 0, 0, 0);
+    al_draw_bitmap_region(bg, right, up, 1, down - up + 1, 1, 0, 0);
 
     // Draw regtangle
     al_set_target_bitmap(bg);
-    al_draw_rectangle(left+1, up+1, right+1, down+1, 
+    al_draw_rectangle(left+1, up+1, right+1, down+1,
                       al_map_rgb(255, 255, 255), 1);
     cleared = false;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ using namespace std;
 
 void initialize_units() {
     std::cerr << "initializing units";
-    Pirate::initialize();
+    PirateBitmap::initialize();
 }
 
 int main(int argc, char const *argv[])
@@ -68,7 +68,8 @@ int main(int argc, char const *argv[])
     // menu.display(200, 200);
 
     // initialization
-    Sprite::initialize(backbuffer);
+    // TODO: initialize backbuffer for all sprites
+    SpriteBase::initialize(backbuffer);
     initialize_units();
 
     // unitManager
@@ -140,10 +141,10 @@ int main(int argc, char const *argv[])
                 }
                 break;
             // case ALLEGRO_EVENT_MOUSE_AXES:
-            //  al_clear_to_color(al_map_rgb(0,0,0));
-            //  al_draw_bitmap(img, ev.mouse.x, ev.mouse.y, 0);
-            //  al_flip_display();
-            //  break;
+            //     al_clear_to_color(al_map_rgb(0,0,0));
+            //     al_draw_bitmap(img, ev.mouse.x, ev.mouse.y, 0);
+            //     al_flip_display();
+            //     break;
 
             case ALLEGRO_EVENT_DISPLAY_CLOSE:
                 repeat = false;

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -1,85 +1,78 @@
 #include <iostream>
 #include "sprite.h"
 
-Sprite::Sprite() :
-    bg(al_create_bitmap(256, 256)),
+SpriteBase::SpriteBase() :
+    bg(al_create_bitmap(framesize, framesize)),
     cleared(true),
     frame(0),
-    framesize(256 /*TODO: unhardcode*/),
     status(IDLE),
     direction(DOWN)
     {
-        if (!bg) std::cerr << "Sprite ERROR: creating bg bitmap\n";
+        if (!bg) std::cerr << "SpriteBase ERROR: creating bg bitmap\n";
     }
 
-Sprite::~Sprite() {
+SpriteBase::~SpriteBase() {
     if (!cleared) clear();
     if (bg) al_destroy_bitmap(bg);
 }
 
-void Sprite::draw(int x, int y, bool selected) {
-    if (!cleared) 
-        std::cerr << "Sprite WARNING: did not call clear before draw\n";
+void SpriteBase::draw(int x, int y, bool selected) {
+    if (!cleared)
+        std::cerr << "SpriteBase WARNING: did not call clear before draw\n";
     cleared = false;
 
     al_set_target_bitmap(bg);
     // Save background
-    al_draw_bitmap_region(backbuffer, x, y, framesize, framesize, 0, 0, 0); 
-    frame = (frame + 1) % n_frames_of(status);
+    al_draw_bitmap_region(backbuffer, x, y, framesize, framesize, 0, 0, 0);
+    frame = (frame + 1) % current_n_frames();
     al_set_target_bitmap(backbuffer);
     if (selected) {
         // TODO: extract and parameterize ellipse position logic
-        al_draw_ellipse(x + framesize / 2, y + 5 * framesize / 6,
-                        framesize/3, framesize/6,
-                        al_map_rgb(255, 255, 255), 1);
+        al_draw_ellipse(x + framesize / 2, y + 5 * framesize / 6, framesize/3,
+                        framesize/6, al_map_rgb(255, 255, 255), 1);
     }
     int flag = direction >= UP_RIGHT ? ALLEGRO_FLIP_HORIZONTAL : 0;
-    al_draw_bitmap_region(bitmap_of(status),
-                          current_x_offset(), current_y_offset(),
-                          framesize, framesize,
-                          x, y, flag);
+    al_draw_bitmap_region(current_bitmap(), current_x_offset(),
+        current_y_offset(), framesize, framesize, x, y, flag);
     pos_x = x;
     pos_y = y;
 }
 
-void Sprite::clear(){
-    if (cleared) std::cerr << "Sprite WARNING: clear called twice\n";
+void SpriteBase::clear(){
+    if (cleared) std::cerr << "SpriteBase WARNING: clear called twice\n";
     cleared = true;
     al_set_target_bitmap(backbuffer);
-    al_draw_bitmap_region(bg, 0, 0, 
-                          framesize, framesize, 
-                          pos_x /*- framesize/2*/, 
-                          pos_y /*- framesize/2*/, 0);
+    al_draw_bitmap_region(bg, 0, 0, framesize, framesize, pos_x, pos_y, 0);
 }
 
-void Sprite::change_status(Status new_status) {
+void SpriteBase::change_status(Status new_status) {
     status = new_status;
 }
 
-void Sprite::change_direction(Direction new_direction) {
+void SpriteBase::change_direction(Direction new_direction) {
     direction = new_direction;
 }
 
-bool Sprite::is_clicked(int x, int y) {
-    return (x > pos_x 
-            && x < pos_x + framesize 
-            && y > pos_y 
-            && y < pos_y + framesize 
-            && al_get_pixel(current_bitmap(), 
-                            frame * framesize + x - pos_x, 
+bool SpriteBase::is_clicked(int x, int y) {
+    return (x > pos_x
+            && x < pos_x + framesize
+            && y > pos_y
+            && y < pos_y + framesize
+            && al_get_pixel(current_bitmap(),
+                            frame * framesize + x - pos_x,
                             framesize * status + y - pos_y).a != 0);
 }
 
-bool Sprite::is_broadly_clicked(int x, int y) {
-    return (x > pos_x 
-            && x < pos_x + framesize 
-            && y > pos_y 
+bool SpriteBase::is_broadly_clicked(int x, int y) {
+    return (x > pos_x
+            && x < pos_x + framesize
+            && y > pos_y
             && y < pos_y + framesize);
 }
 
-ALLEGRO_COLOR Sprite::get_pixel(int x, int y) {
+ALLEGRO_COLOR SpriteBase::get_pixel(int x, int y) {
     if (x > framesize || y > framesize) {
-        std::cerr << "Sprite ERROR: get_pixel: value (" << x 
+        std::cerr << "SpriteBase ERROR: get_pixel: value (" << x
                   << ", " << y << ") out of range\n";
     }
     return al_get_pixel(current_bitmap(),
@@ -87,47 +80,34 @@ ALLEGRO_COLOR Sprite::get_pixel(int x, int y) {
                         framesize * status + y);
 }
 
-int Sprite::get_framesize() {
-    return framesize;
-}
-
-rectangle Sprite::get_rectangle() {
+rectangle SpriteBase::get_rectangle() {
     return rectangle(pos_y, pos_y + framesize, pos_x, pos_x + framesize);
 }
 
-ALLEGRO_BITMAP *Sprite::backbuffer = NULL;
+ALLEGRO_BITMAP *SpriteBase::backbuffer = nullptr;
 
-void Sprite::initialize(ALLEGRO_BITMAP *backbuff) {
+void SpriteBase::initialize(ALLEGRO_BITMAP *backbuff) {
     backbuffer = backbuff;
 }
 
-int Sprite::current_x_offset() {
-    return frame * layout_interpreter.framesize;
+int SpriteBase::current_x_offset() {
+    return frame * framesize;
 }
 
-int Sprite::current_y_offset() {
-    return layout_interpreter.get_y_offset(direction);
+int SpriteBase::current_y_offset() {
+    return y_offsets[direction];
 }
 
-ALLEGRO_BITMAP *Sprite::current_bitmap() {
-    return bitmap_of(status);
-}
+const int SpriteLayoutInterpreter::framesize = 256;
+const int SpriteLayoutInterpreter::y_offsets[8] =
+    {0 * 256, 1 * 256, 2 * 256, 3 * 256, 4 * 256, 3 * 256, 2 * 256, 1 * 256};
 
-int SpriteLayoutInterpreter::x_offsets[5] = {13 * 256,
-                                             24 * 256,
-                                             0 * 256,
-                                             8 * 256,
-                                             18 * 256};
-int SpriteLayoutInterpreter::bitmap_length_by_status[5] = {5, 8, 8, 5, 6};
-int SpriteLayoutInterpreter::y_offsets[8] = {0 * 256, 1 * 256,
-                                             2 * 256, 3 * 256,
-                                             4 * 256, 3 * 256,
-                                             2 * 256, 1 * 256};
+ALLEGRO_BITMAP *PirateBitmap::bmps[STATUS_COUNT] =
+    {nullptr, nullptr, nullptr, nullptr, nullptr};
 
-ALLEGRO_BITMAP *PirateSprite::bmps[STATUS_COUNT] = {nullptr, nullptr, nullptr,
-                                                    nullptr, nullptr};
-int PirateSprite::n_frames[STATUS_COUNT] = {0, 0, 0, 0, 0};
-void PirateSprite::initialize() {
+int PirateBitmap::n_frames[STATUS_COUNT] = {0, 0, 0, 0, 0};
+
+void PirateBitmap::initialize() {
     // TODO unhardcode
     bmps[IDLE] = al_load_bitmap("res/units/pirate/pirate_idle.png");
     bmps[WALK] = al_load_bitmap("res/units/pirate/pirate_walk.png");
@@ -136,10 +116,10 @@ void PirateSprite::initialize() {
     bmps[HIT] = al_load_bitmap("res/units/pirate/pirate_hit.png");
     for (int i = 0; i < STATUS_COUNT; ++i) {
         if (bmps[i]) {
-            /*TODO: unhardcode*/
+            // TODO: unhardcode framesize
             n_frames[i] = al_get_bitmap_width(bmps[i]) / 256;
         } else {
-            std::cerr << "PirateSprite ERROR: failed to load bitmap " 
+            std::cerr << "PirateBitmap ERROR: failed to load bitmap "
                       << i << "\n";
             n_frames[i] = 0;
         }

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -2,34 +2,27 @@
 #include "fastsqrt.h"
 
 #include <iostream>
+#include <math.h>
 
 Unit::Unit(SpriteBase *sprite) :
     selected(false),
     sprite(sprite)
     {}
 
+Direction calculate_direction(float d_x, float d_y) {
+    static const Direction direction_lookup_table[9] =
+       {RIGHT, DOWN_RIGHT, DOWN, DOWN_LEFT, LEFT, UP_LEFT, UP, UP_RIGHT, RIGHT};
+    // angle from positive x axis in radians.
+    // Negative values on 3rd and 4th quadrant
+    double angle = atan2(-d_y, d_x);
+    return direction_lookup_table[(int) (angle * 4 / M_PI + 4.5)];
+}
 void Unit::move(int x, int y) {
-    // TODO: optimize this function
     dst_x = x - sprite->framesize / 2;
     dst_y = y - sprite->framesize / 2;
     float d_x = dst_x - pos_x;
     float d_y = dst_y - pos_y;
-    float tang = d_y / (d_x + 0.0001f);
-    if (tang < 0) tang = - tang;
-    Direction direction;
-    if (tang < 0.41421f) {
-        if (d_x > 0) direction = LEFT;
-        else direction = RIGHT;
-    }
-    else if (tang > 2.41421f) {
-        if (d_y < 0) direction = UP;
-        else direction = DOWN;
-    }
-    else if (d_x > 0 && d_y < 0) direction = UP_LEFT;
-    else if (d_x > 0 && d_y > 0) direction = DOWN_LEFT;
-    else if (d_x < 0 && d_y < 0) direction = UP_RIGHT;
-    else direction = DOWN_RIGHT;
-    sprite->change_direction(direction);
+    sprite->change_direction(calculate_direction(d_x, d_y));
     sprite->change_status(WALK);
 }
 

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -3,15 +3,15 @@
 
 #include <iostream>
 
-Unit::Unit(Sprite *sprite) :
+Unit::Unit(SpriteBase *sprite) :
     selected(false),
     sprite(sprite)
     {}
 
 void Unit::move(int x, int y) {
     // TODO: optimize this function
-    dst_x = x - sprite->get_framesize()/2;
-    dst_y = y - sprite->get_framesize()/2;
+    dst_x = x - sprite->framesize / 2;
+    dst_y = y - sprite->framesize / 2;
     float d_x = dst_x - pos_x;
     float d_y = dst_y - pos_y;
     float tang = d_y / (d_x + 0.0001f);
@@ -76,8 +76,8 @@ int Unit::x() {
 }
 
 bool Unit::operator<(Unit & other) {
-    return pos_y + sprite->get_framesize() 
-           < other.pos_y + other.sprite->get_framesize();
+    return pos_y + sprite->framesize < other.pos_y +
+           other.sprite->framesize;
 }
 
 bool Unit::is_clicked(int x, int y) {
@@ -94,23 +94,3 @@ bool Unit::intersects(rectangle & rect) {
 }
 
 float Unit::speed = 30;
-// TODO delete in destructor
-Pirate::Pirate() :
-    Unit(new PirateSprite())
-    {}
-
-ALLEGRO_BITMAP *Pirate::unit_type_bitmap_ptr = NULL;
-
-void Pirate::initialize() {
-    if (!unit_type_bitmap_ptr) {
-        // al_set_new_bitmap_flags(ALLEGRO_MEMORY_BITMAP);
-        ALLEGRO_BITMAP *bmp = al_load_bitmap("res/units/Pirate2.png");
-        unit_type_bitmap_ptr = bmp;
-        std::cerr << "initialized pirate bitmap to " << bmp;
-    }
-    PirateSprite::initialize();
-}
-
-ALLEGRO_BITMAP *Pirate::unit_type_bitmap() {
-    return unit_type_bitmap_ptr;
-}


### PR DESCRIPTION
Implemented policies for different unit type bitmaps. Sprite inherits from those policies.
Class ConcreteUnit is also template and determines what type of Sprite is passed into Unit's constructor.